### PR TITLE
ios/glview: fix crash when capture image from a zero bounds

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
@@ -559,6 +559,9 @@ typedef NS_ENUM(NSInteger, IJKSDLGLViewApplicationState) {
 
 - (UIImage*)snapshotInternalOnIOS7AndLater
 {
+    if (CGSizeEqualToSize(self.bounds.size, CGSizeZero)) {
+        return nil;
+    }
     UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, 0.0);
     // Render our snapshot into the image context
     [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:NO];


### PR DESCRIPTION
Signed-off-by: Xinzheng Zhang <zhangxzheng@gmail.com>